### PR TITLE
Fix description formatting issue

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -2,9 +2,7 @@ name: perf
 version: '0.3.1.0'
 synopsis: low-level performance statistics
 description: ! '
-
   A set of tools to measure time performance.
-
 '
 category: project
 author: Tony Day


### PR DESCRIPTION
Hpack translates the opening newline to a `.` which cabal interprets as a literal dot, thus leading to a superfluous dot in the generated HTML.