### PR TITLE
perf-core 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,5 @@ install:
 script:
 # Build the package, its tests, and its docs and run the tests
 - stack --no-terminal test --haddock --no-haddock-deps
+- cd perf-core/
+- stack --no-terminal test --haddock --no-haddock-deps

--- a/perf-core/CHANGELOG.md
+++ b/perf-core/CHANGELOG.md
@@ -1,0 +1,5 @@
+	0.1
+	
+	* No Protolude, numhask dependencies
+	* No default langugage extensions in package.yaml
+	* No tdigest

--- a/perf-core/LICENSE
+++ b/perf-core/LICENSE
@@ -1,0 +1,30 @@
+Copyright Author name here (c) 2018
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Author name here nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/perf-core/README.md
+++ b/perf-core/README.md
@@ -1,0 +1,5 @@
+# perf-core
+
+[![Build Status](https://travis-ci.org/tonyday567/perf-core.png)](https://travis-ci.org/tonyday567/perf-core)
+
+TODO Description.

--- a/perf-core/Setup.hs
+++ b/perf-core/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/perf-core/package.yaml
+++ b/perf-core/package.yaml
@@ -1,11 +1,12 @@
 name: perf-core
 version: '0.1'
-synopsis: Low-level performance statistics. 
+synopsis: Low-level run time measurement. 
 description: ! '
   A set of tools to accurately measure time performance of Haskell programs. 
  
   perf-core aims to be lightweight by having minimal dependencies on standard libraries.
 
+  See the Perf module for an example and full API documentation.
 '
 category: project
 author: Tony Day, Marco Zocca

--- a/perf-core/package.yaml
+++ b/perf-core/package.yaml
@@ -1,0 +1,42 @@
+name: perf-core
+version: '0.1'
+synopsis: Low-level performance statistics. 
+description: ! '
+  A set of tools to accurately measure time performance of Haskell programs. 
+ 
+  perf-core aims to be lightweight by having minimal dependencies on standard libraries.
+
+'
+category: project
+author: Tony Day, Marco Zocca
+maintainer: tonyday567@gmail.com
+copyright: Tony Day
+license: BSD3
+github: tonyday567/perf
+extra-source-files:
+- stack.yaml
+- CHANGELOG.md
+library:
+  source-dirs: src
+  exposed-modules:
+  - Perf
+  - Perf.Measure
+  - Perf.Cycle
+  dependencies:
+  - base >=4.7 && <4.11
+  - containers
+  - deepseq
+  - foldl
+  - rdtsc
+  - text
+  - transformers
+  - time
+tests:
+  test:
+    main: LibSpec.hs
+    source-dirs: test
+    dependencies:
+    - base >=4.7 && <5
+    - doctest
+    - perf-core
+    - text

--- a/perf-core/src/Perf.hs
+++ b/perf-core/src/Perf.hs
@@ -1,13 +1,20 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# OPTIONS_GHC -Wall #-}
 
--- | 'PerfT' is a monad transformer designed to collect performance information.
--- The transformer can be used to add performance measurent to an existing code base using 'Measure's.
+-- | == Introduction
+-- 
+-- 'perf' provides high-resolution measurements of the runtime of Haskell functions. It does so by reading the RDTSC register (TSC stands for "time stamp counter"), which is present on all x86 CPUs since the Pentium architecture.
 --
--- For example :
+-- With 'perf' the user may measure both pure and effectful functions, as shown in the Example below. Every piece of code the user may want to profile is passed as an argument to the 'perf' function, along with a text label (that will be displayed in the final summary) and the measurement function (e.g. 'cycles', 'cputime' or 'realtime').
 --
--- >   -- prior to Perfification
+--'PerfT' is a monad transformer designed to collect performance information.
+-- The transformer can be used to add performance measurent to existing code using 'Measure's.
+--
+-- == Example :
+--
+-- Code block to be profiled :
+-- 
 -- >   result <- do
 -- >       txt <- readFile "examples/examples.hs"
 -- >       let n = Text.length txt
@@ -16,7 +23,7 @@
 -- >           (show x :: Text)
 -- >       pure (n, x)
 --
--- And here's the code after 'Perf'ification, measuring performance of the components.
+-- The same code, instrumented with 'perf' :
 --
 -- >   (result', ms) <- runPerfT $ do
 -- >           txt <- perf "file read" cycles $ readFile "examples/examples.hs"
@@ -34,6 +41,9 @@
 -- > print to screen                         1.06e5 cycles
 -- > sum                                     8.12e3 cycles
 --
+-- == Note on RDTSC
+--
+-- Measuring program runtime with RDTSC comes with a set of caveats, such as portability issues, internal timer consistency in the case of multiprocessor architectures, and flucturations due to power throttling. For more details, see : https://en.wikipedia.org/wiki/Time_Stamp_Counter
 module Perf
   ( PerfT
   , Perf
@@ -59,6 +69,8 @@ import qualified Data.Text as T
 import qualified Data.Map as Map
 import Perf.Cycle
 import Perf.Measure
+
+
 
 -- | PerfT is polymorphic in the type of measurement being performed.
 -- The monad stores and produces a Map of labelled measurement values

--- a/perf-core/src/Perf.hs
+++ b/perf-core/src/Perf.hs
@@ -1,0 +1,123 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wall #-}
+
+-- | 'PerfT' is a monad transformer designed to collect performance information.
+-- The transformer can be used to add performance measurent to an existing code base using 'Measure's.
+--
+-- For example :
+--
+-- >   -- prior to Perfification
+-- >   result <- do
+-- >       txt <- readFile "examples/examples.hs"
+-- >       let n = Text.length txt
+-- >       let x = foldl' (+) 0 [1..n]
+-- >       putStrLn $ "sum of one to number of characters is: " <>
+-- >           (show x :: Text)
+-- >       pure (n, x)
+--
+-- And here's the code after 'Perf'ification, measuring performance of the components.
+--
+-- >   (result', ms) <- runPerfT $ do
+-- >           txt <- perf "file read" cycles $ readFile "examples/examples.hs"
+-- >           n <- perf "length" cycles $ pure (Text.length txt)
+-- >           x <- perf "sum" cycles $ pure (foldl' (+) 0 [1..n])
+-- >           perf "print to screen" cycles $
+-- >               putStrLn $ "sum of one to number of characters is: " <>
+-- >               (show x :: Text)
+-- >           pure (n, x)
+--
+-- Running the code produces a tuple of the original computation results, and a Map of performance measurements that were specified.  Indicative results:
+--
+-- > file read                               4.92e5 cycles
+-- > length                                  1.60e6 cycles
+-- > print to screen                         1.06e5 cycles
+-- > sum                                     8.12e3 cycles
+--
+module Perf
+  ( PerfT
+  , Perf
+  , perf
+  , perfN
+  , runPerfT
+  , evalPerfT
+  , execPerfT
+  , module Perf.Cycle
+  , module Perf.Measure
+  )
+  where
+
+import Data.Semigroup
+import Data.Foldable (foldl')
+
+import Control.Monad.IO.Class
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.State (StateT(..), evalStateT, runStateT, execStateT, get, put )
+import Data.Functor.Identity
+import qualified Data.Text as T
+
+import qualified Data.Map as Map
+import Perf.Cycle
+import Perf.Measure
+
+-- | PerfT is polymorphic in the type of measurement being performed.
+-- The monad stores and produces a Map of labelled measurement values
+newtype PerfT m b a = PerfT
+  { runPerf_ :: StateT (Map.Map T.Text b) m a
+  } deriving (Functor, Applicative, Monad)
+
+-- | The obligatory transformer over Identity
+type Perf b a = PerfT Identity b a
+
+instance (MonadIO m) => MonadIO (PerfT m b) where
+  liftIO = PerfT . liftIO
+
+-- | Lift a monadic computation to a PerfT m, providing a label and a 'Measure'.
+perf :: (MonadIO m, Additive b) => T.Text -> Measure m b -> m a -> PerfT m b a
+perf label m a =
+  PerfT $ do
+    st <- get
+    (m', a') <- lift $ runMeasure m a
+    put $ Map.insertWith add label m' st
+    return a'
+
+-- | Lift a monadic computation to a PerfT m, and carry out the computation multiple times.
+perfN ::
+     (MonadIO m, Semigroup b, Monoid b)
+  => Int
+  -> T.Text
+  -> Measure m b
+  -> m a
+  -> PerfT m b a
+perfN n label m a =
+  PerfT $ do
+    st <- get
+    (m', a') <- lift $ runMeasureN n m a
+    put $ Map.insertWith (<>) label m' st
+    return a'
+
+-- | Consume the PerfT layer and return a (result, measurement).
+--
+-- >>> :set -XOverloadedStrings
+-- >>> (cs, result) <- runPerfT $ perf "sum" cycles (pure $ foldl' (+) 0 [0..10000])
+--
+-- > (50005000,fromList [("sum",562028)])
+runPerfT :: PerfT m b a -> m (a, Map.Map T.Text b)
+runPerfT p = flip runStateT Map.empty $ runPerf_ p
+
+-- | Consume the PerfT layer and return the original monadic result.
+-- Fingers crossed, PerfT structure should be completely compiled away.
+--
+-- >>> result <- evalPerfT $ perf "sum" cycles (pure $ foldl' (+) 0 [0..10000])
+--
+-- > 50005000
+evalPerfT :: Monad m => PerfT m b a -> m a
+evalPerfT p = flip evalStateT Map.empty $ runPerf_ p
+
+-- | Consume a PerfT layer and return the measurement.
+--
+-- >>> cs <- execPerfT $ perf "sum" cycles (pure $ foldl' (+) 0 [0..10000])
+--
+-- > fromList [("sum",562028)]
+execPerfT :: Monad m => PerfT m b a -> m (Map.Map T.Text b)
+execPerfT p = flip execStateT Map.empty $ runPerf_ p

--- a/perf-core/src/Perf/Cycle.hs
+++ b/perf-core/src/Perf/Cycle.hs
@@ -1,4 +1,3 @@
--- {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE BangPatterns #-}
 {-# OPTIONS_GHC -Wall #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -37,7 +36,6 @@ import GHC.Word (Word64)
 import System.CPUTime.Rdtsc
 
 -- $setup
--- >>> :set -XNoImplicitPrelude
 -- >>> import Perf.Cycle
 -- >>> let n = 1000
 -- >>> let a = 1000
@@ -259,26 +257,3 @@ ticksWHNFIO n0 a = go a n0 []
 {-# NOINLINE ticksWHNFIO #-}
 
 
-
-
--- 
-
--- instance AdditiveMagma Cycle where
---   plus = (Protolude.+)
-
--- instance AdditiveUnital Cycle where
---   zero = 0
-
--- instance AdditiveAssociative Cycle
-
--- instance AdditiveCommutative Cycle
-
--- instance Additive Cycle
-
--- instance AdditiveInvertible Cycle where
---   negate = Protolude.negate
-
--- instance AdditiveGroup Cycle
-
--- instance ToInteger Cycle where
---     toInteger = Protolude.toInteger

--- a/perf-core/src/Perf/Cycle.hs
+++ b/perf-core/src/Perf/Cycle.hs
@@ -1,0 +1,284 @@
+-- {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE BangPatterns #-}
+{-# OPTIONS_GHC -Wall #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+-- | 'tick' uses the rdtsc chipset to measure time performance of a computation.
+--
+-- The measurement unit - a 'Cycle' - is one oscillation of the chip crystal as measured by the <https://en.wikipedia.org/wiki/Time_Stamp_Counter rdtsc> instruction which inspects the TSC register.
+--
+-- For reference, a computer with a frequency of 2 GHz means that one cycle is equivalent to 0.5 nanoseconds.
+--  
+module Perf.Cycle
+  ( -- $setup
+    Cycle
+  , tick_
+  , warmup
+  , tick
+  , tick'
+  , tickIO
+  , ticks
+  , ticksIO
+  , ns
+  , tickWHNF
+  , tickWHNF'
+  , tickWHNFIO
+  , ticksWHNF
+  , ticksWHNFIO
+  , average
+  )
+  where
+
+import Control.DeepSeq (NFData(..), force)
+import qualified Control.Foldl as L (fold, sum, premap, genericLength)
+import Control.Monad (replicateM)
+import Data.Foldable (foldl')
+import GHC.Word (Word64)
+import System.CPUTime.Rdtsc
+
+-- $setup
+-- >>> :set -XNoImplicitPrelude
+-- >>> import Perf.Cycle
+-- >>> let n = 1000
+-- >>> let a = 1000
+-- >>> let f x = foldl' (+) 0 [1 .. x]
+--
+
+-- | an unwrapped Word64
+type Cycle = Word64
+
+
+
+-- | tick_ measures the number of cycles it takes to read the rdtsc chip twice: the difference is then how long it took to read the clock the second time.
+--
+-- Below are indicative measurements using tick_:
+--
+-- >>> onetick <- tick_
+-- >>> ticks' <- replicateM 10 tick_
+-- >>> manyticks <- replicateM 1000000 tick_
+-- >>> let average = L.fold ((/) <$> L.sum <*> L.genericLength)
+-- >>> let avticks = average (fromIntegral <$> manyticks)
+--
+-- > one tick_: 78 cycles
+-- > next 10: [20,18,20,20,20,20,18,16,20,20]
+-- > average over 1m: 20.08 cycles
+-- > 99.999% perc: 7,986
+-- > 99.9% perc: 50.97
+-- > 99th perc:  24.99
+-- > 40th perc:  18.37
+-- > [min, 10th, 20th, .. 90th, max]:
+-- > 12.00 16.60 17.39 17.88 18.37 18.86 19.46 20.11 20.75 23.04 5.447e5
+--
+-- The distribution of tick_ measurements is highly skewed, with the maximum being around 50k cycles, which is of the order of a GC. The important point on the distribution is around the 30th to 50th percentile, where you get a clean measure, usually free of GC activity and cache miss-fires
+tick_ :: IO Cycle
+tick_ = do
+  t <- rdtsc
+  t' <- rdtsc
+  pure (t' - t)
+
+-- | Warm up the register, to avoid a high first measurement. Without a warmup, one or more larger values can occur at the start of a measurement spree, and often are in the zone of an L2 miss.
+--
+-- >>> t <- tick_ -- first measure can be very high
+-- >>> _ <- warmup 100
+-- >>> t <- tick_ -- should be around 20 (3k for ghci)
+--
+warmup :: Int -> IO Double
+warmup n = do
+  ts <- replicateM n tick_
+  pure $ average ts
+
+-- | tick where the arguments are lazy, so measurement may include evluation of thunks that may constitute f and/or a
+tick' :: (NFData b) => (a -> b) -> a -> IO (Cycle, b)
+tick' f a = do
+  !t <- rdtsc
+  !a' <- pure (force $ f a)
+  !t' <- rdtsc
+  pure (t' - t, a')
+
+-- | `tick f a` strictly evaluates f and a, then deeply evaluates f a, returning a (Cycle, f a)
+--
+-- >>> _ <- warmup 100
+-- >>> (cs, _) <- tick f a
+--
+-- > sum to 1000
+-- > first measure: 1202 cycles
+-- > second measure: 18 cycles
+--
+-- Note that feeding the same computation through tick twice will tend to kick off sharing (aka memoization aka let floating).  Given the importance of sharing to GHC optimisations this is the intended behaviour.  If you want to turn this off then see -fno-full-laziness (and maybe -fno-cse).
+tick :: (NFData b) => (a -> b) -> a -> IO (Cycle, b)
+tick !f !a = tick' f a
+
+tickNoinline :: (NFData b) => (a -> b) -> a -> IO (Cycle, b)
+tickNoinline !f !a = tick' f a
+{-# NOINLINE tickNoinline #-}
+
+-- | measures and deeply evaluates an `IO a`
+--
+-- >>> (cs, _) <- tickIO (pure (f a))
+--
+tickIO :: (NFData a) => IO a -> IO (Cycle, a)
+tickIO a = do
+  t <- rdtsc
+  !a' <- force <$> a
+  t' <- rdtsc
+  pure (t' - t, a')
+
+tickIONoinline :: (NFData a) => IO a -> IO (Cycle, a)
+tickIONoinline = tickIO
+{-# NOINLINE tickIONoinline #-}
+
+-- | n measurements of a tick
+--
+-- returns a list of Cycles and the last evaluated f a
+--
+-- GHC is very good at finding ways to share computation, and anything measuring a computation multiple times is a prime candidate for aggresive ghc treatment. Internally, ticks uses a noinline pragma and a noinline on tick to help reduce the chances of memoization, but this is an inexact science in the hands of he author, at least, so interpret with caution.
+--
+-- 
+-- >>> let n = 1000
+-- >>> (cs, fa) <- ticks n f a
+--
+-- Baseline speed can be highly senistive to the nature of the function trimmings.  Polymorphic functions can tend to be slightly slower, and functions with lambda expressions can experience dramatic slowdowns.
+--
+-- > fMono :: Int -> Int
+-- > fMono x = foldl' (+) 0 [1 .. x]
+-- > fPoly :: (Enum b, Num b, Additive b) => b -> b
+-- > fPoly x = foldl' (+) 0 [1 .. x]
+-- > fLambda :: Int -> Int
+-- > fLambda = \x -> foldl' (+) 0 [1 .. x]
+--
+-- > sum to 1000 n = 1000 prime run: 1.13e3
+-- > run                       first     2nd     3rd     4th     5th  40th %
+-- > ticks                    1.06e3     712     702     704     676    682 cycles
+-- > ticks (lambda)           1.19e3     718     682     684     678    682 cycles
+-- > ticks (poly)             1.64e3  1.34e3  1.32e3  1.32e3  1.32e3 1.31e3 cycles
+--
+ticks :: NFData b => Int -> (a -> b) -> a -> IO ([Cycle], b)
+ticks n0 f a = go f a n0 []
+  where
+    go f' a' n ts
+      | n <= 0 = pure (reverse ts, f a)
+      | otherwise = do
+          (t,_) <- tickNoinline f a
+          go f' a' (n - 1) (t:ts)
+{-# NOINLINE ticks #-}
+
+-- | n measuremenst of a tickIO
+--
+-- returns an IO tuple; list of Cycles and the last evaluated f a
+--
+-- >>> (cs, fa) <- ticksIO n (pure $ f a)
+--
+-- > ticksIO                     834     752     688     714     690    709 cycles
+-- > ticksIO (lambda)            822     690     720     686     688    683 cycles
+-- > ticksIO (poly)           1.01e3     688     684     682     712    686 cycles
+ticksIO :: (NFData a) => Int -> IO a -> IO ([Cycle], a)
+ticksIO n0 a = go a n0 []
+  where
+    go a' n ts
+      | n <= 0 = do
+            a'' <- a'
+            pure (reverse ts, a'')
+      | otherwise = do
+          (t,_) <- tickIONoinline a'
+          go a' (n - 1) (t:ts)
+{-# NOINLINE ticksIO #-}
+
+-- | make a series of measurements on a list of a's to be applied to f, for a tick function.
+--
+-- Tends to be fragile to sharing issues, but very useful to determine computation Order
+--
+-- > ns ticks n f [1,10,100,1000]
+--
+-- > sum to's [1,10,100,1000]
+-- > tickns n fMono:  17.8 23.5 100 678
+--
+ns :: NFData b => (a -> IO ([Cycle],b)) -> [a] -> IO ([[Cycle]], [b])
+ns t as = do
+  cs <- sequence $ t <$> as
+  pure (fst <$> cs, snd <$> cs)
+
+-- | average of a Cycle foldable
+--
+-- > cAv <- average <$> ticks n f a
+--
+average :: (Foldable f) => f Cycle -> Double
+average = L.fold (L.premap fromIntegral ((/) <$> L.sum <*> L.genericLength))
+
+
+
+-- | WHNF version
+tickWHNF :: (a -> b) -> a -> IO (Cycle, b)
+tickWHNF !f !a = tickWHNF' f a
+
+tickWHNFNoinline :: (a -> b) -> a -> IO (Cycle, b)
+tickWHNFNoinline !f !a = tickWHNF' f a
+{-# NOINLINE tickWHNFNoinline #-}
+
+-- | WHNF version
+tickWHNF' :: (a -> b) -> a -> IO (Cycle, b)
+tickWHNF' f a = do
+  !t <- rdtsc
+  !a' <- pure (f a)
+  !t' <- rdtsc
+  pure (t' - t, a')
+
+-- | WHNF version
+tickWHNFIO :: IO a -> IO (Cycle, a)
+tickWHNFIO a = do
+  t <- rdtsc
+  !a' <- a
+  t' <- rdtsc
+  pure (t' - t, a')
+
+tickWHNFIONoinline :: IO a -> IO (Cycle, a)
+tickWHNFIONoinline = tickWHNFIO
+{-# NOINLINE tickWHNFIONoinline #-}
+
+-- | WHNF version
+ticksWHNF :: Int -> (a -> b) -> a -> IO ([Cycle], b)
+ticksWHNF n0 f a = go f a n0 []
+  where
+    go f' a' n ts
+      | n <= 0 = pure (reverse ts, f a)
+      | otherwise = do
+          (t,_) <- tickWHNFNoinline f a
+          go f' a' (n - 1) (t:ts)
+{-# NOINLINE ticksWHNF #-}
+
+-- | WHNF version
+ticksWHNFIO :: Int -> IO a -> IO ([Cycle], a)
+ticksWHNFIO n0 a = go a n0 []
+  where
+    go a' n ts
+      | n <= 0 = do
+            a'' <- a'
+            pure (reverse ts, a'')
+      | otherwise = do
+          (t,_) <- tickWHNFIONoinline a'
+          go a' (n - 1) (t:ts)
+{-# NOINLINE ticksWHNFIO #-}
+
+
+
+
+-- 
+
+-- instance AdditiveMagma Cycle where
+--   plus = (Protolude.+)
+
+-- instance AdditiveUnital Cycle where
+--   zero = 0
+
+-- instance AdditiveAssociative Cycle
+
+-- instance AdditiveCommutative Cycle
+
+-- instance Additive Cycle
+
+-- instance AdditiveInvertible Cycle where
+--   negate = Protolude.negate
+
+-- instance AdditiveGroup Cycle
+
+-- instance ToInteger Cycle where
+--     toInteger = Protolude.toInteger

--- a/perf-core/src/Perf/Measure.hs
+++ b/perf-core/src/Perf/Measure.hs
@@ -17,8 +17,6 @@ module Perf.Measure
   )
   where
 
-import Control.Monad.IO.Class (MonadIO(..))
-
 import Data.Time.Clock
 import GHC.Word (Word64)
 import Control.Monad (replicateM_)

--- a/perf-core/src/Perf/Measure.hs
+++ b/perf-core/src/Perf/Measure.hs
@@ -62,13 +62,14 @@ data Measure m b = forall a. (Additive b) => Measure
   , poststep :: a -> m b
   }
 
+
 -- | Measure a single effect.
 --
 -- >>> r <- runMeasure count (pure "joy")
 -- >>> r
 -- (1,"joy")
 --
-runMeasure :: MonadIO m => Measure m b -> m a -> m (b, a)
+runMeasure :: Monad m => Measure m b -> m a -> m (b, a)
 runMeasure (Measure _ pre post) a = do
   p <- pre
   !a' <- a
@@ -81,7 +82,7 @@ runMeasure (Measure _ pre post) a = do
 -- >>> r
 -- (1,"joys")
 --
-runMeasureN :: MonadIO m => Int -> Measure m b -> m a -> m (b, a)
+runMeasureN :: Monad m => Int -> Measure m b -> m a -> m (b, a)
 runMeasureN n (Measure _ pre post) a = do
   p <- pre
   replicateM_ (n - 1) a
@@ -94,10 +95,8 @@ runMeasureN n (Measure _ pre post) a = do
 -- >>> r <- cost count
 -- >>> r
 -- 1
-cost :: MonadIO m => Measure m b -> m b
-cost (Measure _ pre post) = do
-  p <- pre
-  post p
+cost :: Monad m => Measure m b -> m b
+cost (Measure _ pre post) = pre >>= post 
 
 -- | a measure using 'getCPUTime' from System.CPUTime (unit is picoseconds)
 --
@@ -130,7 +129,7 @@ realtime = Measure m0 start stop
       t <- getCurrentTime
       return $ diffUTCTime t a
 
--- | a measure used to count iterations
+-- | a 'Measure' used to count iterations
 --
 -- >>> r <- runMeasure count (pure ())
 -- >>> r
@@ -143,7 +142,7 @@ count = Measure m0 start stop
     start = return ()
     stop () = return 1
 
--- | a Measure using the 'rdtsc' chip set (units are in cycles)
+-- | a 'Measure' using the 'rdtsc' CPU register (units are in cycles)
 --
 -- >>> r <- runMeasureN 1000 cycles (pure ())
 -- 

--- a/perf-core/src/Perf/Measure.hs
+++ b/perf-core/src/Perf/Measure.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE BangPatterns #-}
--- {-# LANGUAGE NoImplicitPrelude #-}
 {-# OPTIONS_GHC -Wall #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -160,24 +159,3 @@ cycles = Measure m0 start stop
       t <- rdtsc
       return $ t - a
 
-
-
-
--- 
-
--- instance AdditiveMagma NominalDiffTime where
---   plus = (P.+)
-
--- instance AdditiveUnital NominalDiffTime where
---   zero = 0
-
--- instance AdditiveAssociative NominalDiffTime
-
--- instance AdditiveCommutative NominalDiffTime
-
--- instance Additive NominalDiffTime
-
--- instance AdditiveInvertible NominalDiffTime where
---   negate = P.negate
-
--- instance AdditiveGroup NominalDiffTime

--- a/perf-core/src/Perf/Measure.hs
+++ b/perf-core/src/Perf/Measure.hs
@@ -1,0 +1,183 @@
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE BangPatterns #-}
+-- {-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wall #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+-- | Specification of a performance measurement type suitable for the 'PerfT' monad transformer.
+module Perf.Measure
+  ( Measure(..)
+  , runMeasure
+  , runMeasureN
+  , cost
+  , cputime
+  , realtime
+  , count
+  , cycles
+  , Additive(..)
+  )
+  where
+
+import Control.Monad.IO.Class (MonadIO(..))
+
+import Data.Time.Clock
+import GHC.Word (Word64)
+import Control.Monad (replicateM_)
+import Data.Foldable (foldl')
+import Perf.Cycle 
+import System.CPUTime
+import System.CPUTime.Rdtsc
+
+
+-- | Lightweight 'Additive' class. 
+class Num a => Additive a where
+  add :: a -> a -> a
+  zero :: a
+
+instance Additive Int where
+  add = (+)
+  zero = 0
+
+instance Additive Integer where
+  add = (+)
+  zero = 0
+
+instance Additive Word64 where
+  add = (+)
+  zero = 0
+
+instance Additive NominalDiffTime where
+  add = (+)
+  zero = 0
+  
+
+
+-- | A Measure consists of a monadic effect prior to measuring, a monadic effect to finalise the measurement, and the value measured
+--
+-- For example, the measure specified below will return 1 every time measurement is requested, thus forming the base of a simple counter for loopy code.
+--
+-- >>> let count = Measure 0 (pure ()) (pure 1)
+data Measure m b = forall a. (Additive b) => Measure
+  { measure :: b
+  , prestep :: m a
+  , poststep :: a -> m b
+  }
+
+-- | Measure a single effect.
+--
+-- >>> r <- runMeasure count (pure "joy")
+-- >>> r
+-- (1,"joy")
+--
+runMeasure :: MonadIO m => Measure m b -> m a -> m (b, a)
+runMeasure (Measure _ pre post) a = do
+  p <- pre
+  !a' <- a
+  m' <- post p
+  return (m', a')
+
+-- | Measure once, but run an effect multiple times.
+--
+-- >>> r <- runMeasureN 1000 count (pure "joys")
+-- >>> r
+-- (1,"joys")
+--
+runMeasureN :: MonadIO m => Int -> Measure m b -> m a -> m (b, a)
+runMeasureN n (Measure _ pre post) a = do
+  p <- pre
+  replicateM_ (n - 1) a
+  !a' <- a
+  m' <- post p
+  return (m', a')
+
+-- | cost of a measurement in terms of the Measure's own units
+--
+-- >>> r <- cost count
+-- >>> r
+-- 1
+cost :: MonadIO m => Measure m b -> m b
+cost (Measure _ pre post) = do
+  p <- pre
+  post p
+
+-- | a measure using 'getCPUTime' from System.CPUTime (unit is picoseconds)
+--
+-- >>> r <- runMeasure cputime (pure $ foldl' (+) 0 [0..1000])
+--
+-- > (34000000,500500)
+--
+cputime :: Measure IO Integer
+cputime = Measure 0 start stop
+  where
+    start = getCPUTime
+    stop a = do
+      t <- getCPUTime
+      return $ t - a
+
+
+
+-- | a measure using 'getCurrentTime' (unit is 'NominalDiffTime' which prints as seconds)
+--
+-- >>> r <- runMeasure realtime (pure $ foldl' (+) 0 [0..1000])
+--
+-- > (0.000046s,500500)
+--
+realtime :: Measure IO NominalDiffTime
+realtime = Measure m0 start stop
+  where
+    m0 = zero :: NominalDiffTime
+    start = getCurrentTime
+    stop a = do
+      t <- getCurrentTime
+      return $ diffUTCTime t a
+
+-- | a measure used to count iterations
+--
+-- >>> r <- runMeasure count (pure ())
+-- >>> r
+-- (1,())
+--
+count :: Measure IO Int
+count = Measure m0 start stop
+  where
+    m0 = 0 :: Int
+    start = return ()
+    stop () = return 1
+
+-- | a Measure using the 'rdtsc' chip set (units are in cycles)
+--
+-- >>> r <- runMeasureN 1000 cycles (pure ())
+-- 
+-- > (120540,()) -- ghci-level
+-- > (18673,())  -- compiled with -O2
+--
+cycles :: Measure IO Cycle
+cycles = Measure m0 start stop
+  where
+    m0 = 0
+    start = rdtsc
+    stop a = do
+      t <- rdtsc
+      return $ t - a
+
+
+
+
+-- 
+
+-- instance AdditiveMagma NominalDiffTime where
+--   plus = (P.+)
+
+-- instance AdditiveUnital NominalDiffTime where
+--   zero = 0
+
+-- instance AdditiveAssociative NominalDiffTime
+
+-- instance AdditiveCommutative NominalDiffTime
+
+-- instance Additive NominalDiffTime
+
+-- instance AdditiveInvertible NominalDiffTime where
+--   negate = P.negate
+
+-- instance AdditiveGroup NominalDiffTime

--- a/perf-core/stack.yaml
+++ b/perf-core/stack.yaml
@@ -1,0 +1,7 @@
+resolver: nightly-2017-12-27
+
+packages:
+  - '.'
+
+extra-deps:
+  - rdtsc-1.3.0.1

--- a/perf-core/test/LibSpec.hs
+++ b/perf-core/test/LibSpec.hs
@@ -1,10 +1,7 @@
-{-# language OverloadedStrings #-}
 {-# OPTIONS_GHC -Wall #-}
 module Main where
 
 import Test.DocTest
-
--- import Data.Text
 
 main :: IO ()
 main = do
@@ -15,14 +12,3 @@ main = do
   putStrLn ("Perf DocTest")
   doctest ["src/Perf.hs"]
 
-
--- main :: IO ()
--- main = hspec spec
-
--- spec :: Spec
--- spec =
---   describe "Lib" $ do
---     it "works" $ do
---       True `shouldBe` True
---     prop "ourAdd is commutative" $ \x y ->
---       ourAdd x y `shouldBe` ourAdd y x

--- a/perf-core/test/LibSpec.hs
+++ b/perf-core/test/LibSpec.hs
@@ -1,0 +1,28 @@
+{-# language OverloadedStrings #-}
+{-# OPTIONS_GHC -Wall #-}
+module Main where
+
+import Test.DocTest
+
+-- import Data.Text
+
+main :: IO ()
+main = do
+  putStrLn ("Perf.Cycle DocTest")
+  doctest ["src/Perf/Cycle.hs"]
+  putStrLn ("Perf.Measure DocTest")
+  doctest ["src/Perf/Measure.hs"]
+  putStrLn ("Perf DocTest")
+  doctest ["src/Perf.hs"]
+
+
+-- main :: IO ()
+-- main = hspec spec
+
+-- spec :: Spec
+-- spec =
+--   describe "Lib" $ do
+--     it "works" $ do
+--       True `shouldBe` True
+--     prop "ourAdd is commutative" $ \x y ->
+--       ourAdd x y `shouldBe` ourAdd y x


### PR DESCRIPTION
In my eternal quest for lightweight Haskell libraries, I've extracted this gem out of 'perf'.

The idea is to package only minimal functionality and in particular depend strictly on base and a handful of standard packages, such that other projects can build on top of this without worrying too much about large transitive dependency trees. In particular I'm thinking of building a new 'perf-golden' in the spirit of 'tasty-golden' to track regressions across versions.

To the point of this PR (as I've written in CHANGELOG.md):

* No numhask, no protolude
* No tdigest 
* No default language extensions in package.yaml (makes it easier to track style changes).

The export structure is identical to 'perf', so in a subsequent stage, we can import 'perf-core' into 'perf' and re-add the missing functionality such as the tdigest summaries.

Hope you like it!



